### PR TITLE
fix: filter jupyter warning and improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Default is github-pr-check.
 
 **Optional**. Additional reviewdog flags. Defaults to `""`.
 
+## Outputs
+
+### `BLACK_CHECK_FILE_PATHS`
+
+Contains all the files that would be changed by black.
+
 ## Format your code
 
 This action is meant to annotate any possible changes that would need to be made to make your code adhere to the [black formatting guidelines](github.com/psf/black). It does not apply these changes to your codebase. If you also want to apply the changes to your repository, you can use the [reviewdog/action-suggester](https://github.com/reviewdog/action-suggester). You can find examples of how this is done can be found in [rickstaa/action-black](https://github.com/rickstaa/action-black/)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,15 +40,11 @@ if [[ "${INPUT_REPORTER}" = 'github-pr-review' ]]; then
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     ${INPUT_REVIEWDOG_FLAGS} || reviewdog_exit_val="$?"
 
-  # regenerate black_check_output that command same as non-github-pr-review.
-  # because after process need normal generated black_check_output value.
-  # read and drop exit code
-  black_exit_val2="0"
+  # Re-generate black output. Needed because the output of the '--diff' option can not
+  # be used to retrieve the files that black would change
   # shellcheck disable=SC2086,SC2034
-  black_check_output="$(black --check . ${INPUT_BLACK_ARGS} 2>&1)" ||
-    black_exit_val2="$?"
+  black_check_output="$(black --check . ${INPUT_BLACK_ARGS} 2>&1)" || true
 else
-
   echo "[action-black] Checking python code with the black formatter and reviewdog..."
   # shellcheck disable=SC2086
   black_check_output="$(black --check . ${INPUT_BLACK_ARGS} 2>&1)" ||
@@ -65,17 +61,23 @@ else
     ${INPUT_REVIEWDOG_FLAGS} || reviewdog_exit_val="$?"
 fi
 
+# Remove jupyter warning if present
+black_check_output="${black_check_output//"Skipping .ipynb files as Jupyter dependencies are not installed."/}"
+black_check_output="${black_check_output//"You can fix this by running \`\`pip install black[jupyter]\`\`"/}"
+
 # Output the checked file paths that would be formatted
 black_check_file_paths=()
 while read -r line; do
-  black_check_file_paths+=("$line")
+  if [ "$line" != "" ]; then
+    black_check_file_paths+=("$line")
+  fi
 done <<<"${black_check_output//"would reformat "/}"
 
 # remove last two lines of black output, since they are irrelevant
 unset "black_check_file_paths[-1]"
 unset "black_check_file_paths[-1]"
 
-# append the array elements to BLACK_CHECK_FILE_PATHS in github env
+# Append the array elements to BLACK_CHECK_FILE_PATHS in github env
 # shellcheck disable=SC2129
 echo "BLACK_CHECK_FILE_PATHS<<EOF" >>"$GITHUB_ENV"
 echo "${black_check_file_paths[@]}" >>"$GITHUB_ENV"


### PR DESCRIPTION
This commit makes sure that the jupyter warning that is thrown by black when jupyter is not installed and the repo contains `.ipynb` files does not show in the `BLACK_CHECK_FILE_PATHS` variable. It also adds documentaiton for the `BLACK_CHECK_FILE_PATHS`.